### PR TITLE
Remove errant quote

### DIFF
--- a/dev-setup.html
+++ b/dev-setup.html
@@ -157,7 +157,7 @@ in your Terminal. (You can also customize what you set PROJECT_HOME to, if
 you wish):</p>
 <div class="highlight-python"><div class="highlight"><pre>echo &quot;export WORKON_HOME=$HOME/.virtualenvs
 export PROJECT_HOME=$HOME/Devel
-source /usr/local/bin/virtualenvwrapper.sh&quot; &gt;&gt; ~/.bash_profile
+source /usr/local/bin/virtualenvwrapper.sh &gt;&gt; ~/.bash_profile
 source ~/.bash_profile
 </pre></div>
 </div>


### PR DESCRIPTION
I was receiving warnings that virtualenvwrapper.sh could not be found.  Removing the errant quote resolved the issue for me.