### PR TITLE
Add letsencrypt_domains to list of pillar variables

### DIFF
--- a/source/margarita/states.rst
+++ b/source/margarita/states.rst
@@ -493,6 +493,8 @@ Pillar configuration:
   be configured to use this domain name.
 * ``letsencrypt`` (boolean): If True, use `letsencrypt.org <https://letsencrypt.org>`_
   to get a certificate.
+* ``letsencrypt_domains`` (list): List of domain names. We'll request SSL certs for
+  each domain name in this list. If this is empty or not set, we'll use ``domain``.
 * ``admin_email`` (email address): If ``letsencrypt`` is true, this is required to
   provide an email address for `letsencrypt.org <https://letsencrypt.org>`_ to use.
   This should be a dev team group email address, not an individual's email address.


### PR DESCRIPTION
`letsencrypt_domains` is listed in the prose, but I figured it made sense to add it to the list of pillar variables, for completeness.